### PR TITLE
Add `hovercards`

### DIFF
--- a/reserved-names.json
+++ b/reserved-names.json
@@ -116,7 +116,7 @@
   "home",
   "hooks",
   "hosting",
-	"hovercards",
+  "hovercards",
   "identity",
   "images",
   "inbox",

--- a/reserved-names.json
+++ b/reserved-names.json
@@ -116,6 +116,7 @@
   "home",
   "hooks",
   "hosting",
+	"hovercards",
   "identity",
   "images",
   "inbox",


### PR DESCRIPTION
It seems that GitHub added a new reserved name `hovercards`.