### PR TITLE
Add sponsors to reserved list

### DIFF
--- a/reserved-names.json
+++ b/reserved-names.json
@@ -216,6 +216,7 @@
   "signup",
   "site",
   "spam",
+  "sponsors",
   "ssh",
   "staff",
   "starred",


### PR DESCRIPTION
Sponsors is a reserved word now, https://github.com/sponsors.