### PR TITLE
Update `c` redirect location

### DIFF
--- a/oddballs.json
+++ b/oddballs.json
@@ -18,7 +18,7 @@
 	"account": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/settings/profile", "included": true},
 	"apps": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/marketplace", "included": true},
 	"blog": {"reserved": true, "taken": false, "typical": false, "redirect": "https://blog.github.com", "included": true},
-	"c": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/contact", "included": true},
+	"c": {"reserved": true, "taken": false, "typical": false, "redirect": "https://support.github.com/", "included": true},
 	"contributing": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/about/careers", "included": true},
 	"customer": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/business/customers", "included": true},
 	"customers": {"reserved": true, "taken": false, "typical": false, "redirect": "https://github.com/business/customers", "included": true},


### PR DESCRIPTION
Well, `https://github.com/contact` will redirect to `https://support.github.com/` but I guess it won't hurt to save a redirect.