### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+env: {}
+
+# DO NOT EDIT BELOW, USE: npx ghat fregante/ghatemplates/node --exclude 'jobs.Build'
+
+name: CI
+on:
+  - pull_request
+  - push
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install
+        run: npm ci || npm install
+      - name: XO
+        run: npx xo
+  Test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: install
+        run: npm ci || npm install
+      - name: build
+        run: npm run build --if-present
+      - name: AVA
+        run: npx ava


### PR DESCRIPTION
I saw CI was missing. Let me know if you'd like to drop https://github.com/fregante/ghat

Also if you'd like I can copy [a workflow](https://github.com/fregante/github-url-detection/blob/master/.github/workflows/publish.yml) to enable _manual_ publishing via GitHub Actions.