### PR TITLE
Meta: Avoid third-party action to publish package

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,3 +1,7 @@
+env: {}
+
+# DO NOT EDIT BELOW, USE: npx ghat fregante/ghatemplates/npm-publish
+
 # Collaborators can publish a new version of what's on master via "workflow_dispatch"
 # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 
@@ -17,16 +21,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 20
-      - run: npm install
-      - uses: fregante/setup-git-token@v1
+      - uses: actions/setup-node@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          node-version: 14.x
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci || npm install
+      - uses: fregante/setup-git-user@v1
       - run: npm version ${{ github.event.inputs.Version }}
-      - uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: git push --follow-tags
       - uses: notlmn/release-with-changelog@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          exclude: '^Meta|^\d\.\d\.\d$|^Readme|readme$|Lint|dependencies'
+          exclude: true


### PR DESCRIPTION
1. Replaces `setup-git-token` with config-less `setup-git-user`
2. Drops `JS-DevTools/npm-publish` in favor of `setup-node` + native `$ npm publish`
3. Updates `notlmn/release-with-changelog` configuration
4. Uses `ghat` for future updates: https://github.com/fregante/ghatemplates#npm-publish (we can drop the first 4 lines if you don't like them)